### PR TITLE
Add dll pinning for windows to prevent dll unloading

### DIFF
--- a/plugin_export.go
+++ b/plugin_export.go
@@ -5,12 +5,41 @@ package vst2
 //#include "include/vst.h"
 import "C"
 import (
+	"reflect"
+	"runtime"
+	"syscall"
 	"unsafe"
 )
+
+//fix vst host crash in windows, when plugin gets unloaded by pinning dll
+func preventDllFromUnload() {
+	const (
+		GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS = 4
+		GET_MODULE_HANDLE_EX_FLAG_PIN          = 1
+	)
+	var (
+		kernel32, _          = syscall.LoadLibrary("kernel32.dll")
+		getModuleHandleEx, _ = syscall.GetProcAddress(kernel32, "GetModuleHandleExW")
+		handle               uintptr
+	)
+	defer func(handle syscall.Handle) {
+		err := syscall.FreeLibrary(handle)
+		if err != nil {
+			panic("cant unload kernel32 lib")
+		}
+	}(kernel32)
+	if _, _, callErr := syscall.Syscall(uintptr(getModuleHandleEx), 3, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, reflect.ValueOf(preventDllFromUnload).Pointer(), uintptr(unsafe.Pointer(&handle))); callErr != 0 {
+		panic("cant pin dll")
+	}
+	return
+}
 
 // instantiate go plugin
 //export newGoPlugin
 func newGoPlugin(cp *C.CPlugin, c C.HostCallback) {
+	if runtime.GOOS == "windows" {
+		preventDllFromUnload()
+	}
 	p, d := PluginAllocator(callbackHandler{c}.host(cp))
 	p.dispatchFunc = d.dispatchFunc(p.Parameters)
 	cp.magic = C.int(EffectMagic)

--- a/plugin_export_notwin.go
+++ b/plugin_export_notwin.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package vst2
+
+func loadHook() {}

--- a/plugin_export_windows.go
+++ b/plugin_export_windows.go
@@ -7,6 +7,9 @@ import (
 )
 
 //fix vst host crash in windows, when plugin gets unloaded by pinning dll
+//see https://docs.microsoft.com/en-gb/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandleexa?redirectedfrom=MSDN
+//for information about GET_MODULE_HANDLE_EX_FLAG_PIN
+//workaround for issue: https://github.com/golang/go/issues/11100
 func loadHook() {
 	const (
 		GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS = 4

--- a/plugin_export_windows.go
+++ b/plugin_export_windows.go
@@ -1,0 +1,29 @@
+package vst2
+
+import (
+	"reflect"
+	"syscall"
+	"unsafe"
+)
+
+//fix vst host crash in windows, when plugin gets unloaded by pinning dll
+func loadHook() {
+	const (
+		GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS = 4
+		GET_MODULE_HANDLE_EX_FLAG_PIN          = 1
+	)
+	var (
+		kernel32, _          = syscall.LoadLibrary("kernel32.dll")
+		getModuleHandleEx, _ = syscall.GetProcAddress(kernel32, "GetModuleHandleExW")
+		handle               uintptr
+	)
+	defer func(handle syscall.Handle) {
+		err := syscall.FreeLibrary(handle)
+		if err != nil {
+			panic("cant unload kernel32 lib")
+		}
+	}(kernel32)
+	if _, _, callErr := syscall.Syscall(uintptr(getModuleHandleEx), 3, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, reflect.ValueOf(loadHook).Pointer(), uintptr(unsafe.Pointer(&handle))); callErr != 0 {
+		panic("cant pin dll")
+	}
+}


### PR DESCRIPTION
VST hosts like Renoise, FLStudio unloads the dll, when the last instance was removed from the song. This unloading causing a crash of the VST host on windows systems. With pinning, the dll gets only unloaded, when the main process (daw) will be closed.

Related to #45