### PR TITLE
Fix parameter not visible in Bitwig

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -78,6 +78,9 @@ func (d Dispatcher) dispatchFunc(p Plugin) dispatchFunc {
 			s := (*ascii8)(ptr)
 			copyASCII(s[:], p.Parameters[index].Unit)
 		case PlugCanBeAutomated:
+			if p.Parameters[index].NotAutomated {
+				return 0
+			}
 			return 1
 		case plugSetBufferSize:
 			if d.SetBufferSizeFunc == nil {

--- a/plugin.go
+++ b/plugin.go
@@ -77,6 +77,8 @@ func (d Dispatcher) dispatchFunc(p Plugin) dispatchFunc {
 		case plugGetParamLabel:
 			s := (*ascii8)(ptr)
 			copyASCII(s[:], p.Parameters[index].Unit)
+		case PlugCanBeAutomated:
+			return 1
 		case plugSetBufferSize:
 			if d.SetBufferSizeFunc == nil {
 				return 0

--- a/vst.go
+++ b/vst.go
@@ -745,10 +745,11 @@ const (
 type (
 	// Parameter refers to plugin parameter that can be mutated in the pipe.
 	Parameter struct {
-		Name       string
-		Unit       string
-		Value      float32
-		ValueLabel string
+		Name         string
+		Unit         string
+		Value        float32
+		ValueLabel   string
+		NotAutomated bool
 	}
 
 	// Preset refers to plugin presets.


### PR DESCRIPTION
Demo plugin for issue #45 in Bitwig don't show any parameters. Parameters needs to be automatable. Currently return always true.