### PR TITLE
Add plugin build constraints

### DIFF
--- a/plugin_export_notwin.go
+++ b/plugin_export_notwin.go
@@ -1,3 +1,4 @@
+// +build plugin
 // +build !windows
 
 package vst2

--- a/plugin_export_windows.go
+++ b/plugin_export_windows.go
@@ -1,3 +1,5 @@
+// +build plugin
+
 package vst2
 
 import (


### PR DESCRIPTION
There are two files with functionality related to plugins that don't have `plugin` build constraint.