### PR TITLE
Necessary changes and fixes to make synth plugins

### DIFF
--- a/events.go
+++ b/events.go
@@ -72,7 +72,6 @@ func (e *EventsPtr) Event(i int) Event {
 
 // Free memory allocated for container.
 func (e *EventsPtr) Free() {
-	C.free(unsafe.Pointer(e.events))
 	C.free(unsafe.Pointer(e))
 }
 

--- a/include/event/event.c
+++ b/include/event/event.c
@@ -16,9 +16,8 @@ typedef struct Event
 } Event;
 
 Events* newEvents(int32_t numEvents) {
-	Events *e = calloc(1,sizeof(Events));
+	Events *e = calloc(1, sizeof(Events) + sizeof(void *) * numEvents);
 	e->numEvents = numEvents;
-	e->events = calloc(numEvents, sizeof(e->events));
 	return e;
 }
 

--- a/include/vst.h
+++ b/include/vst.h
@@ -81,11 +81,11 @@ typedef CPlugin* (*EntryPoint)(HostCallback host);
 struct Events
 {
 	// Number of Events in array.
-	int32_t numEvents;
+	int64_t numEvents;
 	// Not used.
 	int64_t reserved;
 	// Event pointer array, variable size.
-	void** events;
+	void* events[];
 };
 
 // Bridge to allocate events structure.

--- a/plugin.go
+++ b/plugin.go
@@ -47,6 +47,7 @@ type (
 		Parameters []*Parameter
 		dispatchFunc
 		PluginCanDoFunc
+		ProcessEventsFunc
 	}
 
 	// Dispatcher handles plugin dispatch calls from the host.
@@ -59,6 +60,8 @@ type (
 
 	// ProcessFloatFunc defines logic for float signal processing.
 	ProcessFloatFunc func(in, out FloatBuffer)
+
+	ProcessEventsFunc func(*EventsPtr)
 
 	PluginCanDoFunc func(PluginCanDoString) CanDoResponse
 
@@ -108,6 +111,11 @@ func (d Dispatcher) dispatchFunc(p Plugin) dispatchFunc {
 				return int64(p.PluginCanDoFunc(s))
 			}
 			return 0
+		case PlugProcessEvents:
+			var e *EventsPtr = (*EventsPtr)(ptr)
+			if p.ProcessEventsFunc != nil {
+				p.ProcessEventsFunc(e)
+			}
 		default:
 			return 0
 		}

--- a/plugin.go
+++ b/plugin.go
@@ -37,6 +37,7 @@ type (
 		Vendor         string
 		InputChannels  int
 		OutputChannels int
+		Flags          PluginFlag
 		inputDouble    DoubleBuffer
 		outputDouble   DoubleBuffer
 		inputFloat     FloatBuffer

--- a/plugin.go
+++ b/plugin.go
@@ -46,6 +46,7 @@ type (
 		ProcessFloatFunc
 		Parameters []*Parameter
 		dispatchFunc
+		PluginCanDoFunc
 	}
 
 	// Dispatcher handles plugin dispatch calls from the host.
@@ -58,6 +59,8 @@ type (
 
 	// ProcessFloatFunc defines logic for float signal processing.
 	ProcessFloatFunc func(in, out FloatBuffer)
+
+	PluginCanDoFunc func(PluginCanDoString) CanDoResponse
 
 	callbackHandler struct {
 		callback C.HostCallback
@@ -99,6 +102,12 @@ func (d Dispatcher) dispatchFunc(p Plugin) dispatchFunc {
 			copyASCII(s[:], p.Vendor)
 		case PlugGetPlugCategory:
 			return int64(p.Category)
+		case PlugCanDo:
+			if p.PluginCanDoFunc != nil {
+				s := PluginCanDoString(C.GoString((*C.char)(ptr)))
+				return int64(p.PluginCanDoFunc(s))
+			}
+			return 0
 		default:
 			return 0
 		}

--- a/plugin_export.go
+++ b/plugin_export.go
@@ -19,6 +19,7 @@ func newGoPlugin(cp *C.CPlugin, c C.HostCallback) {
 	cp.numParams = C.int(len(p.Parameters))
 	cp.version = C.int(p.Version)
 	cp.uniqueID = C.int(uint(p.UniqueID[0])<<24 | uint(p.UniqueID[1])<<16 | uint(p.UniqueID[2])<<8 | uint(p.UniqueID[3])<<0)
+	cp.flags = cp.flags | C.int(p.Flags)
 	if p.ProcessDoubleFunc != nil {
 		cp.flags = cp.flags | C.int(PluginDoubleProcessing)
 		p.inputDouble = DoubleBuffer{data: make([]*C.double, p.InputChannels)}

--- a/vst.go
+++ b/vst.go
@@ -689,6 +689,8 @@ type (
 	// PluginCanDoString are constants that can be used to check plugin
 	// capabilities.
 	PluginCanDoString string
+	// CanDoResponse lists the possible return values for CanDo queries
+	CanDoResponse int64
 )
 
 const (
@@ -743,6 +745,15 @@ const (
 	PluginCanMIDIProgramNames PluginCanDoString = "midiProgramNames"
 	// PluginCanBypass plugin supports function SetBypass.
 	PluginCanBypass PluginCanDoString = "bypass"
+)
+
+const (
+	// YesCanDo is returned by CanDo queries when plugin/host is certain that it supports a feature.
+	YesCanDo CanDoResponse = 1
+	// NoCanDo is returned by CanDo queries when plugin/host is certain that it does not support a feature.
+	NoCanDo CanDoResponse = -1
+	// MaybeCanDo is returned by CanDo queries when plugin/host doesn't know if it supports a particular feature.
+	MaybeCanDo CanDoResponse = 0
 )
 
 type (


### PR DESCRIPTION
Here's a couple of changes that were necessary to compile synthesizer plugins with the vst2 package (to resolve #61):

1) The events field in the structure Events in vst.h was defined wrong; it was void** events where as it should have been void* events[]. In other words: it should be a variable size structure, with some "header", followed by a list of pointers, and should be allocated with a single calloc (and freed with a single free).

2) The user has now mechanism to define arbitrary PluginFlags; specifically, to enable defining vst2.PluginIsSynth flag for the synth

3) I also gave the user a way to define a callback function for responding to PlugCanDo opcode. In my case, I use it to respond positively to vst2.PluginCanReceiveEvents, vst2.PluginCanReceiveMIDIEvent, and vst2.PluginCanReceiveTimeInfo

4) Finally, I gave the user a way to define a callback function for responding to PlugProcessEvents opcodes, to receive MIDI events from the host.