### PR TITLE
Clean resources upon plugClose and give user callback to do so too

### DIFF
--- a/plugin_export.go
+++ b/plugin_export.go
@@ -40,7 +40,14 @@ func newGoPlugin(cp *C.CPlugin, c C.HostCallback) {
 // global dispatch, calls real plugin dispatch.
 func dispatchPluginBridge(cp *C.CPlugin, opcode int32, index int32, value int64, ptr unsafe.Pointer, opt float32) int64 {
 	p := getPlugin(cp)
-	return p.dispatchFunc(PluginOpcode(opcode), index, value, ptr, opt)
+	pluginOpcode := PluginOpcode(opcode)
+	ret := p.dispatchFunc(pluginOpcode, index, value, ptr, opt)
+	if pluginOpcode == plugClose {
+		plugins.RLock()
+		defer plugins.RUnlock()
+		delete(plugins.mapping, uintptr(unsafe.Pointer(cp)))
+	}
+	return ret
 }
 
 //export processDoublePluginBridge


### PR DESCRIPTION
I am allocating resources that require releasing when plugin is closed e.g. signaling to certain background goroutine that it should close. To do this, I react to plugClose opcode by removing the plugin from the map and I give a callback to user to do any additional cleanup that (s)he wants.

Not sure if this is the best way to go about this, what do you think?