### PR TITLE
feat: enable user to pass TimeInfoFlag to the HostGetTimeInfoFunc

### DIFF
--- a/host.go
+++ b/host.go
@@ -18,5 +18,5 @@ type (
 	// HostGetProcessLevel returns the context of execution.
 	HostGetProcessLevelFunc func() ProcessLevel
 	// HostGetTimeInfo returns current time info.
-	HostGetTimeInfoFunc func() *TimeInfo
+	HostGetTimeInfoFunc func(flags TimeInfoFlag) *TimeInfo
 )

--- a/host_callback.go
+++ b/host_callback.go
@@ -76,7 +76,7 @@ func (h Host) Callback() HostCallbackFunc {
 			}
 		case HostGetTime:
 			if h.GetTimeInfo != nil {
-				return int64(uintptr(unsafe.Pointer(h.GetTimeInfo())))
+				return int64(uintptr(unsafe.Pointer(h.GetTimeInfo(TimeInfoFlag(value)))))
 			}
 		}
 		return 0

--- a/plugin.go
+++ b/plugin.go
@@ -137,8 +137,8 @@ func (h callbackHandler) host(cp *C.CPlugin) Host {
 		GetProcessLevel: func() ProcessLevel {
 			return ProcessLevel(C.callbackHost(h.callback, cp, C.int(HostGetCurrentProcessLevel), 0, 0, nil, 0))
 		},
-		GetTimeInfo: func() *TimeInfo {
-			return (*TimeInfo)(unsafe.Pointer(uintptr(C.callbackHost(h.callback, cp, C.int(HostGetTime), 0, 0, nil, 0))))
+		GetTimeInfo: func(flags TimeInfoFlag) *TimeInfo {
+			return (*TimeInfo)(unsafe.Pointer(uintptr(C.callbackHost(h.callback, cp, C.int(HostGetTime), 0, C.longlong(flags), nil, 0))))
 		},
 	}
 }


### PR DESCRIPTION
The HostGetTime opcode takes a TimeInfoFlag parameter, which tells the host what fields of the TimeInfo should be filled. Currently, it was always 0. Renoise was kind enough to fill in all fields regardless of what was requested, but FruityLoops not. I added ability for the user to pass this parameter. I had to send vst2.TempoValid to FruityLoops in order to get the tempo.