### PR TITLE
feat: enable plugin to respond to GetChunk / SetChunk ops

### DIFF
--- a/plugin_export.go
+++ b/plugin_export.go
@@ -30,6 +30,13 @@ func newGoPlugin(cp *C.CPlugin, c C.HostCallback) {
 		p.inputFloat = FloatBuffer{data: make([]*C.float, p.InputChannels)}
 		p.outputFloat = FloatBuffer{data: make([]*C.float, p.OutputChannels)}
 	}
+
+	// GetChunk and SetChunk should be defined in pairs. If both are
+	// defined, we advertise the capability to save and load plugin settings,
+	// by settings flag PluginProgramChunks.
+	if d.GetChunkFunc != nil && d.SetChunkFunc != nil {
+		cp.flags = cp.flags | C.int(PluginProgramChunks)
+	}
 	p.dispatchFunc = d.dispatchFunc(p)
 	plugins.Lock()
 	plugins.mapping[uintptr(unsafe.Pointer(cp))] = &p


### PR DESCRIPTION
This pull request enables plugins to respond to the plugGetChunk and plugSetChunk opcodes. They allow marshaling the entire state of the plugin into project files. Used in situations, where the plugin is handling its own settings e.g. through its own GUI. Note that plugin needs advertise this to the host, by setting flag vst2.PluginProgramChunks