### PR TITLE
fix: parameter type should be C.int64_t not C.longlong

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -157,7 +157,7 @@ func (h callbackHandler) host(cp *C.CPlugin) Host {
 			return ProcessLevel(C.callbackHost(h.callback, cp, C.int(HostGetCurrentProcessLevel), 0, 0, nil, 0))
 		},
 		GetTimeInfo: func(flags TimeInfoFlag) *TimeInfo {
-			return (*TimeInfo)(unsafe.Pointer(uintptr(C.callbackHost(h.callback, cp, C.int(HostGetTime), 0, C.longlong(flags), nil, 0))))
+			return (*TimeInfo)(unsafe.Pointer(uintptr(C.callbackHost(h.callback, cp, C.int(HostGetTime), 0, C.int64_t(flags), nil, 0))))
 		},
 	}
 }


### PR DESCRIPTION
This will fix building on Linux AMD64. Fix was proposed and tested on Windows by @vsariola :tada: Thanks for that :heart: 

Closes #67 