### PR TITLE
feat: add UpdateDisplay() to Host signaling param change

### DIFF
--- a/host.go
+++ b/host.go
@@ -9,6 +9,7 @@ type (
 		GetBufferSize   HostGetBufferSizeFunc
 		GetProcessLevel HostGetProcessLevelFunc
 		GetTimeInfo     HostGetTimeInfoFunc
+		UpdateDisplay   HostUpdateDisplayFunc
 	}
 
 	// HostGetSampleRateFunc returns host sample rate.
@@ -19,4 +20,6 @@ type (
 	HostGetProcessLevelFunc func() ProcessLevel
 	// HostGetTimeInfo returns current time info.
 	HostGetTimeInfoFunc func(flags TimeInfoFlag) *TimeInfo
+	// HostUpdateDisplay tells there are changes & requests GUI redraw. Returns true on success
+	HostUpdateDisplayFunc func() bool
 )

--- a/plugin.go
+++ b/plugin.go
@@ -159,6 +159,9 @@ func (h callbackHandler) host(cp *C.CPlugin) Host {
 		GetTimeInfo: func(flags TimeInfoFlag) *TimeInfo {
 			return (*TimeInfo)(unsafe.Pointer(uintptr(C.callbackHost(h.callback, cp, C.int(HostGetTime), 0, C.int64_t(flags), nil, 0))))
 		},
+		UpdateDisplay: func() bool {
+			return C.callbackHost(h.callback, cp, C.int(HostUpdateDisplay), 0, 0, nil, 0) > 0
+		},
 	}
 }
 


### PR DESCRIPTION
I have a separate GUI running for the VST. I need to signal the host that parameters have changed to request GUI refresh. This is done by sending HostUpdateDisplay opcode. Host.UpdateDisplay() now does exactly that.